### PR TITLE
fixes #54. Adds woe_label sql functions and updates readme with new rank

### DIFF
--- a/geocoder/admin1/README.md
+++ b/geocoder/admin1/README.md
@@ -49,5 +49,6 @@ The table contains the following columns to be populated:
 | 2 			| Natural Earth 			| name_alt | alternate spelling | 
 | 3				| Natural Earth				| abbrev   | abbreviation |
 | 4				| Natural Earth				| postal   | postal code  |
-| 5 			| Natural Earth 			| gn_name  | formal english name  | 					
+| 5 			| Natural Earth 			| gn_name  | formal english name  |
+| 6 			| Natural Earth 			| woe_label  | woe label name  | 					
 

--- a/geocoder/admin1/sql/build_admin1_synonyms.sql
+++ b/geocoder/admin1/sql/build_admin1_synonyms.sql
@@ -100,6 +100,46 @@ WHERE adm1_code IN (
     WHERE qs_source = 'Natural Earth'
 );
 
+-- add woe_label as rank = 6 where label strings are like 'name, iso3_adm0_code, adm0_name'
+INSERT INTO admin1_synonyms(name, rank, adm0_a3, global_id)
+    (
+      SELECT substring(woe_label from '#"%#",%,%' for '#'), 6, adm0_a3, 
+
+      (
+        SELECT qs_adm1.global_id FROM qs_adm1 
+        WHERE qs_source = 'Natural Earth' 
+        AND ne_admin1_v3.adm1_code = qs_a1_lc
+        )
+      FROM ne_admin1_v3 
+      WHERE array_length(string_to_array(woe_label, ','),1) = 3 
+      AND adm1_code IN 
+        (
+         SELECT qs_a1_lc 
+         FROM qs_adm1 
+         WHERE qs_source = 'Natural Earth'
+        )
+    );
+
+-- add woe_label as rank = 6 where label strings are like 'name'
+INSERT INTO admin1_synonyms(name, rank, adm0_a3, global_id)
+    (
+      SELECT woe_label, 6, adm0_a3, 
+
+      (
+        SELECT qs_adm1.global_id FROM qs_adm1 
+        WHERE qs_source = 'Natural Earth' 
+        AND ne_admin1_v3.adm1_code = qs_a1_lc
+        )
+      FROM ne_admin1_v3 
+      WHERE array_length(string_to_array(woe_label, ','),1) = 1
+      AND adm1_code IN 
+        (
+         SELECT qs_a1_lc 
+         FROM qs_adm1 
+         WHERE qs_source = 'Natural Earth'
+        )
+    );
+
 -- remove all cases where name is NULL
 DELETE FROM admin1_synonyms WHERE name IS NULL;
 


### PR DESCRIPTION
- Adds new rank (6) for woe_label names from Natural Earth.
- Includes two SQL INSERT functions that add the names to the synonyms table depending on the shape of the string in woe_label

**These functions should be reviewed to check ignored rows due to iso3_adm0 mismatch. There's a new issue for this.**

Closes #54 
