### PR TITLE
Adds new query for subunit column and modifies ranks

### DIFF
--- a/geocoder/admin0/README.md
+++ b/geocoder/admin0/README.md
@@ -39,13 +39,13 @@ The table contains the following columns to be populated:
 
 3. **notes:** Extra information as the source of the data. Use: 'data source: X'.
 
-4. **rank:** Use '9' for manually curated additions.
+4. **rank:** Use '10' for manually curated additions.
 
 The following query can be used:
 
 
 ````
-INSERT INTO admin0_synonym_additions (adm0_a3, name, notes, rank) VALUES ($iso3_code, $synonym, $notes, 9)
+INSERT INTO admin0_synonym_additions (adm0_a3, name, notes, rank) VALUES ($iso3_code, $synonym, $notes, 10)
 ````
 
 **Note:** If you have a complete dataset of synonyms to be included, you will need to add it as part of the build script. If you need to add single entries for synonyms, they can be included in the `admin0_synonym_additions` table manually (or using the previously defined SQL query).
@@ -63,7 +63,9 @@ INSERT INTO admin0_synonym_additions (adm0_a3, name, notes, rank) VALUES ($iso3_
 | 6           | natural earth 10m countries | brk_name      | ?                    |
 | 7           | natural earth 10m countries | formal_fr     | formal french        |
 | 8           | natural earth 10m countries | iso_a2     | 2 digit country code        |
-| 9           | admin0_synonym_additions | n/a     | manually curated additions       |
+| 9           | natural earth 10m countries | subunit     | complete literal name       |
+| 10           | admin0_synonym_additions | n/a     | manually curated additions       |
+
 
 __notes:__ 
 

--- a/geocoder/admin0/sql/build_synonym_table.sql
+++ b/geocoder/admin0/sql/build_synonym_table.sql
@@ -73,14 +73,21 @@ SELECT
 FROM
     ne_admin0_v3;
 
--- insert manual additions with a rank = 9    
+-- insert subunit as name with a rank = 9    
+INSERT INTO admin0_synonyms (name, rank, adm0_a3)
+SELECT
+    subunit, 9, adm0_a3
+FROM
+    ne_admin0_v3;
+
+-- insert manual additions with a rank = 10    
 INSERT INTO admin0_synonyms (name, rank, adm0_a3)
 SELECT
     name, rank, adm0_a3
 FROM
     admin0_synonym_additions
 WHERE
-    rank=9;
+    rank=10;
 
 -- remove all cases where name is NULL
 DELETE FROM admin0_synonyms WHERE name IS NULL;


### PR DESCRIPTION
- Adds new rank 9 for subunits in ne_adm0 dataset.
- Modifies manual synonyms to be rank 10.
- Updates documentation and procedures of the README.md file.

The manual synonyms table already has all the ranks set to 10 and the synonym table has been updated. 

I'd want to highlight that countries like South Korea or South Sudan, with which we were having problems, are appearing now.
