### PR TITLE
Oriol adds

### DIFF
--- a/common-data/README.md
+++ b/common-data/README.md
@@ -1258,7 +1258,7 @@ Data library
 
 **Sync Table**: `false`
 
-** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+**Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
 
 #### Municipalities of Spain with displaced Canary Islands
 **Description**: Geometries for the municipalities of Spain with the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
@@ -1271,7 +1271,7 @@ Data library
 
 **Sync Table**: `false`
 
-** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+**Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
 
 #### Provinces of Spain
 **Description**: Geometries for the provinces of Spain. Official dataset from Instituto Geográfico Nacional de España.
@@ -1284,7 +1284,7 @@ Data library
 
 **Sync Table**: `false`
 
-** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+**Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
 
 #### Provinces of Spain with displaced Canary Islands
 **Description**: Geometries for the provinces of Spain with the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
@@ -1297,7 +1297,7 @@ Data library
 
 **Sync Table**: `false`
 
-** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+**Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
 
 #### Autonomous Communities of Spain.
 **Description**: Geometries for  the autonomous communities of Spain. Official dataset from Instituto Geográfico Nacional de España.
@@ -1310,7 +1310,7 @@ Data library
 
 **Sync Table**: `false`
 
-** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+**Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
 
 #### Autonomous communities of Spain with displaced Canary Islands
 **Description**: Geometries for  the autonomous communities of Spain with  the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
@@ -1323,7 +1323,7 @@ Data library
 
 **Sync Table**: `false`
 
-** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+**Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
 
 ***
 

--- a/common-data/README.md
+++ b/common-data/README.md
@@ -1247,6 +1247,84 @@ Data library
 
 **Source URL**: http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/structures.html
 
+#### Municipalities of Spain
+**Description**: Geometries for the municipalities of Spain. Official dataset from Instituto Geográfico Nacional de España.
+
+**Source**: [IGN/CNIG](https://www.cnig.es/)
+
+**License**: 
+
+**Table Name**: ign_spanish_adm3_municipalities
+
+**Sync Table**: `false`
+
+** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+
+#### Municipalities of Spain with displaced Canary Islands
+**Description**: Geometries for the municipalities of Spain with the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
+
+**Source**: [IGN/CNIG](https://www.cnig.es/)
+
+**License**: 
+
+**Table Name**: ign_spanish_adm3_municipalities_displaced_canary
+
+**Sync Table**: `false`
+
+** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+
+#### Provinces of Spain
+**Description**: Geometries for the provinces of Spain. Official dataset from Instituto Geográfico Nacional de España.
+
+**Source**: [IGN/CNIG](https://www.cnig.es/)
+
+**License**: 
+
+**Table Name**: ign_spanish_adm2_provinces
+
+**Sync Table**: `false`
+
+** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+
+#### Provinces of Spain with displaced Canary Islands
+**Description**: Geometries for the provinces of Spain with the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
+
+**Source**: [IGN/CNIG](https://www.cnig.es/)
+
+**License**: 
+
+**Table Name**: ign_spanish_adm2_provinces_displaced_canary
+
+**Sync Table**: `false`
+
+** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+
+#### Autonomous Communities of Spain.
+**Description**: Geometries for  the autonomous communities of Spain. Official dataset from Instituto Geográfico Nacional de España.
+
+**Source**: [IGN/CNIG](https://www.cnig.es/)
+
+**License**: 
+
+**Table Name**: ign_spanish_adm1_ccaa
+
+**Sync Table**: `false`
+
+** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+
+#### Autonomous communities of Spain with displaced Canary Islands
+**Description**: Geometries for  the autonomous communities of Spain with  the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
+
+**Source**: [IGN/CNIG](https://www.cnig.es/)
+
+**License**: 
+
+**Table Name**: ign_spanish_adm1_ccaa_displaced_canary
+
+**Sync Table**: `false`
+
+** Source URL**: http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip
+
 ***
 
 ### Historic

--- a/common-data/README.md
+++ b/common-data/README.md
@@ -1250,9 +1250,9 @@ Data library
 #### Municipalities of Spain
 **Description**: Geometries for the municipalities of Spain. Official dataset from Instituto Geográfico Nacional de España.
 
-**Source**: [IGN/CNIG](https://www.cnig.es/)
+**Source**: [Instituto Geográfico Nacional](http://www.ign.es/)
 
-**License**: 
+**License**: Public data - Attribution required  
 
 **Table Name**: ign_spanish_adm3_municipalities
 
@@ -1263,9 +1263,9 @@ Data library
 #### Municipalities of Spain with displaced Canary Islands
 **Description**: Geometries for the municipalities of Spain with the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
 
-**Source**: [IGN/CNIG](https://www.cnig.es/)
+**Source**: [Instituto Geográfico Nacional](http://www.ign.es/)
 
-**License**: 
+**License**: Public data - Attribution required  
 
 **Table Name**: ign_spanish_adm3_municipalities_displaced_canary
 
@@ -1276,9 +1276,9 @@ Data library
 #### Provinces of Spain
 **Description**: Geometries for the provinces of Spain. Official dataset from Instituto Geográfico Nacional de España.
 
-**Source**: [IGN/CNIG](https://www.cnig.es/)
+**Source**: [Instituto Geográfico Nacional](http://www.ign.es/)
 
-**License**: 
+**License**: Public data - Attribution required 
 
 **Table Name**: ign_spanish_adm2_provinces
 
@@ -1289,9 +1289,9 @@ Data library
 #### Provinces of Spain with displaced Canary Islands
 **Description**: Geometries for the provinces of Spain with the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
 
-**Source**: [IGN/CNIG](https://www.cnig.es/)
+**Source**: [Instituto Geográfico Nacional](http://www.ign.es/)
 
-**License**: 
+**License**: Public data - Attribution required
 
 **Table Name**: ign_spanish_adm2_provinces_displaced_canary
 
@@ -1302,9 +1302,9 @@ Data library
 #### Autonomous Communities of Spain.
 **Description**: Geometries for  the autonomous communities of Spain. Official dataset from Instituto Geográfico Nacional de España.
 
-**Source**: [IGN/CNIG](https://www.cnig.es/)
+**Source**: [Instituto Geográfico Nacional](http://www.ign.es/)
 
-**License**: 
+**License**: Public data - Attribution required
 
 **Table Name**: ign_spanish_adm1_ccaa
 
@@ -1315,9 +1315,9 @@ Data library
 #### Autonomous communities of Spain with displaced Canary Islands
 **Description**: Geometries for  the autonomous communities of Spain with  the Canary Islands displaced. Official dataset from Instituto Geográfico Nacional de España.
 
-**Source**: [IGN/CNIG](https://www.cnig.es/)
+**Source**: [Instituto Geográfico Nacional](http://www.ign.es/)
 
-**License**: 
+**License**: Public data - Attribution required
 
 **Table Name**: ign_spanish_adm1_ccaa_displaced_canary
 


### PR DESCRIPTION
Add the official datasets from Instituto Geográfico Nacional de España of the municipalities, provinces and autonomous communities (with and without the Canary Islands displaced) inside the Administrative regions section.