### PR TITLE
Add Republic of the Congo to synonym additions

### DIFF
--- a/geocoder/admin0/data/admin0_synonym_additions.csv
+++ b/geocoder/admin0/data/admin0_synonym_additions.csv
@@ -14,6 +14,7 @@ COD,"Congo, Dem. Rep.",data source: world bank,10
 COD,Democratic republic of the Congo,,10
 COD, The Democratic Republic of the Congo,,10
 COG,The Republic of the Congo,,10
+COG,Republic of the Congo,,10
 COG,"Congo, Rep.",data source: world bank,10
 COG,Congo (CG),,10
 EGY,"Egypt, Arab Rep.",data source: world bank,10


### PR DESCRIPTION
Fixes #216


In a "patch" way:

`INSERT INTO admin0_synonym_additions (adm0_a3, name, rank) VALUES ('COG', 'Republic of the Congo', 10)`

and run `admin0/sql/build_synonym_table.sql`