### PR TITLE
Add download and apply patches scripts

### DIFF
--- a/geocoder/geocoder_apply_patches.sh
+++ b/geocoder/geocoder_apply_patches.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+function usage() {
+  cat <<EOF
+Usage:
+  $(basename $0) DBUSER DBNAME *.sql
+E.g:
+  $(basename $0) development_cartodb_user_87ddf981-25c7-4538-9910-0eb4342f2483 cartodb_dev_user_87ddf981-25c7-4538-9910-0eb4342f2483_db patches/*.sql
+EOF
+}
+
+
+if [ "$#" -lt "3" ]; then
+    usage
+    exit 1
+fi
+
+DBUSER=$1
+DBNAME=$2
+shift; shift;
+DUMP_FILES="$@"
+
+echo
+echo "About to import the following files: ${DUMP_FILES}"
+for i in $DUMP_FILES; do
+    echo
+    echo "Importing ${i}..."
+    psql \
+        --username=${DBUSER} \
+        --dbname=${DBNAME} \
+        --set=ON_ERROR_STOP=on \
+        --single-transaction \
+        --file=${i} || exit 1
+    echo "Done with ${i}."
+    echo
+done
+
+echo
+echo "** Everything OK **"

--- a/geocoder/geocoder_download_patches.sh
+++ b/geocoder/geocoder_download_patches.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+TARGET_DIR_PATCHES=data_patches
+BASE_URL=https://s3.amazonaws.com/data.cartodb.net/geocoding/dumps
+VERSION=0.0.1
+
+PATCHES_LIST="20160203_countries_bh_isocode.sql
+20160622_countries_synonym_congo.sql"
+
+mkdir -p $TARGET_DIR_PATCHES
+
+for file in $PATCHES_LIST; do
+    url="${BASE_URL}/${VERSION}/patches/$file"
+
+    wget -c --directory-prefix=$TARGET_DIR_PATCHES $url
+done


### PR DESCRIPTION
Hey @rafatower,

I basically duplicated our current scripts but applied them to the patches. I generated them and uploaded them to a specific `/patches` folder inside version 0.0.1.

I separated this process from the download/load dumps procedure because in general patches will be applied in a different moment in time. It's been tested locally and running as expected:

```
ubuntu@cdb:~/www/production.cartodb.com/current/carlachecks$ sh geocoder_apply_patches.sh development_cartodb_user_367c0edc-b2ad-4bab-ad43-3d58a6179a93 cartodb_dev_user_367c0edc-b2ad-4bab-ad43-3d58a6179a93_db data_patches/*.sql

About to import the following files: data_patches/20160203_countries_bh_isocode.sql data_patches/20160622_countries_synonym_congo.sql

Importing data_patches/20160203_countries_bh_isocode.sql...
DELETE 1
Done with data_patches/20160203_countries_bh_isocode.sql.


Importing data_patches/20160622_countries_synonym_congo.sql...
INSERT 0 1
Done with data_patches/20160622_countries_synonym_congo.sql.
````
