### PR TITLE
Taiwan: distinguish between Hsinchu City and Hsinchu County

### DIFF
--- a/geocoder/admin1/patches/20180117_hsinchu_synonyms.sql
+++ b/geocoder/admin1/patches/20180117_hsinchu_synonyms.sql
@@ -1,0 +1,4 @@
+UPDATE global_province_polygons
+  SET synonyms = array_append(array_remove(synonyms, 'hsinchu'), 'hsinchu county'),
+      "name" = 'Hsinchu County'
+  WHERE adm1_code = 'TWN-1162';

--- a/geocoder/geocoder_download_patches.sh
+++ b/geocoder/geocoder_download_patches.sh
@@ -6,7 +6,8 @@ VERSION=0.0.1
 
 PATCHES_LIST="20160203_countries_bh_isocode.sql
 20160622_countries_synonym_congo.sql
-20171004_merge_corsica_and_france.sql"
+20171004_merge_corsica_and_france.sql
+20180117_hsinchu_synonyms.sql"
 
 mkdir -p $TARGET_DIR_PATCHES
 


### PR DESCRIPTION
Fixes https://github.com/CartoDB/support/issues/1199

Adds the "hsinchu county" to the admin1 geocoder. Removes "hsinchu" as that synonym was shared by the city and the count. Seems like the commonly accepted practice is to point to the city.