### PR TITLE
[ch124507] Add new SQL patch adding 'North Macedonia'

### DIFF
--- a/geocoder/admin0/patches/20210118_add_renamed_country_north_macedonia.sql
+++ b/geocoder/admin0/patches/20210118_add_renamed_country_north_macedonia.sql
@@ -1,0 +1,9 @@
+DO $$
+  DECLARE updated INTEGER;
+BEGIN
+  SELECT count(*) FROM admin0_synonyms WHERE adm0_a3 = 'MKD' GROUP BY adm0_a3 HAVING count(*) > 0 INTO updated;
+  IF updated = 6 THEN
+    INSERT INTO admin0_synonyms (name, rank, adm0_a3, name_) SELECT 'North Macedonia' as name, 6, adm0_a3, 'northmacedonia' as name_ FROM admin0_synonyms WHERE name_ = 'macedonia';
+    INSERT INTO admin0_synonyms (name, rank, adm0_a3, name_) SELECT 'Republic of North Macedonia' as name, 7, adm0_a3, 'republicofnorthmacedonia' as name_ FROM admin0_synonyms WHERE name_ = 'macedonia';
+  END IF;
+END$$;

--- a/geocoder/geocoder_download_patches.sh
+++ b/geocoder/geocoder_download_patches.sh
@@ -10,7 +10,8 @@ PATCHES_LIST="20160203_countries_bh_isocode.sql
 20180117_hsinchu_synonyms.sql
 20180306_add_ssd_rows_for_south_sudan.sql
 20181011_add_synonyms_for_swaziland.sql
-20190111_france_regions_typos.sql"
+20190111_france_regions_typos.sql
+20210118_add_renamed_country_north_macedonia.sql"
 
 mkdir -p $TARGET_DIR_PATCHES
 


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/124507/outdated-carto-country-geocoding-does-not-match-carto-basemap)

### Context

- After a [naming dispute](https://en.wikipedia.org/wiki/Macedonia_naming_dispute), `Macedonia` country was renamed to `North Macedonia`. Our basemaps are updated, but those names are not recognized in geocoding processes.

### Changes

- Create a new SQL patch to add the new official names (`North Macedonia` and `Republic of North Macedonia`) as aliases of `MKD`.