### PR TITLE
[sc208491] Fix 'Haut-Rhin' France region typo

### DIFF
--- a/geocoder/admin1/patches/20220325_france_region_haut-rhin_typo.sql
+++ b/geocoder/admin1/patches/20220325_france_region_haut-rhin_typo.sql
@@ -1,0 +1,3 @@
+UPDATE global_province_polygons
+  SET synonyms = array_append(array_remove(synonyms, 'haut-rhin'), 'haut-rhin')
+  WHERE adm1_code = 'FRA-5296';

--- a/geocoder/geocoder_download_patches.sh
+++ b/geocoder/geocoder_download_patches.sh
@@ -11,7 +11,8 @@ PATCHES_LIST="20160203_countries_bh_isocode.sql
 20180306_add_ssd_rows_for_south_sudan.sql
 20181011_add_synonyms_for_swaziland.sql
 20190111_france_regions_typos.sql
-20210118_add_renamed_country_north_macedonia.sql"
+20210118_add_renamed_country_north_macedonia.sql
+20220325_france_region_haut-rhin_typo.sql"
 
 mkdir -p $TARGET_DIR_PATCHES
 


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.shortcut.com/cartoteam/story/208491/pilote-modernisation-typo-in-internal-geocoder-france-departments-provinces)

### Context

`Haute-Rhin` France region should be [`Haut-Rhin`](https://en.wikipedia.org/wiki/Haut-Rhin).

### Changes

- Adding `haut-rhin` as alias.